### PR TITLE
Remove skipping of filenames not ending in "test.html"

### DIFF
--- a/confluence-markdown-export.py
+++ b/confluence-markdown-export.py
@@ -151,10 +151,6 @@ class Converter:
             if not path.endswith(".html"):
                 continue
 
-            if not path.endswith("test.html"):
-                print("SKIPPING", path)
-                continue
-
             print("Converting {}".format(path))
             with open(path) as f:
                 data = f.read()


### PR DESCRIPTION
All filenames _not_ ending in 'test.html' were skipping conversion. Could be a typo or a bit of leftover test code. In any case, I just removed the check.