### PR TITLE
Fix missing path separator in attachments download url

### DIFF
--- a/confluence-markdown-export.py
+++ b/confluence-markdown-export.py
@@ -75,7 +75,7 @@ class Exporter:
                 att_title = i["title"]
                 download = i["_links"]["download"]
 
-                att_url = self.__url + "wiki/" + download
+                att_url = self.__url.rstrip("/") + "/wiki/" + download
                 att_sanitized_name = self.__sanitize_filename(att_title)
                 att_filename = os.path.join(page_output_dir, ATTACHMENT_FOLDER_NAME, att_sanitized_name)
 


### PR DESCRIPTION
Download of attachments only worked if the Confluence site URL ended in `/`, otherwise the download URL was malformed (`${hostname}wiki`). I added an explicit path separator, so it works whether the site URL ends with `/` or not.