### PR TITLE
Enhance filename sanitization & Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ A simple tool to export Confluence pages to Markdown format. **Note:** This code
 ## Installation
 
 1. Clone the repository:
-    ```sh
-    git clone https://github.com/josh-abram/confluence-markdown-exporter.git
-    cd confluence-markdown-exporter
-    ```
+   ```sh
+   git clone https://github.com/josh-abram/confluence-markdown-exporter.git
+   cd confluence-markdown-exporter
+   ```
 
 2. Install the required packages:
-    ```sh
-    pip install -r requirements.txt
-    ```
+   ```sh
+   pip install -r requirements.txt
+   ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,59 @@
-### A very simple Confluence to Markdown exporter.
+# Confluence to Markdown Exporter
 
-This code is not written with security in mind, do NOT run it on a repository that can contain mailicious
-page titles.
+A simple tool to export Confluence pages to Markdown format. **Note:** This code is not written with security in mind. Do **not** run it on a repository that can contain malicious page titles.
 
+## Installation
 
-### Usage
-1. Install requirements: <code>pip3 install -r requirements.txt</code>
-2. Run the script: <code>python3.9 confluence-markdown-export.py url username token out_dir</code>
-   providing URL e.g. https://YOUR_PROJECT.atlassian.net, login details - username and API Token,
-   and output directory, e.g. ./output_dir
+1. Clone the repository:
+    ```sh
+    git clone https://github.com/josh-abram/confluence-markdown-exporter.git
+    cd confluence-markdown-exporter
+    ```
 
-The secret token can be generated under Profile -> Security -> Manage API Tokens
+2. Install the required packages:
+    ```sh
+    pip install -r requirements.txt
+    ```
+
+## Usage
+
+Run the script with the following command:
+
+```sh
+python3 confluence-markdown-export.py <url> <username> <token> <out_dir> [--space <space>] [--skip-attachments] [--no-fetch]
+```
+
+### Arguments
+
+- **url**: The URL of the Confluence instance (e.g., `https://YOUR_PROJECT.atlassian.net`).
+- **username**: Your Confluence username.
+- **token**: Your Confluence API token.
+- **out_dir**: The directory to output the files to.
+
+### Optional Arguments
+
+- **--space**: Specify the space key to export. If not provided, all spaces will be exported.
+- **--skip-attachments**: Skip fetching attachments.
+- **--no-fetch**: Only run the Markdown conversion without fetching data from Confluence.
+
+### Example
+
+```sh
+python3 confluence-markdown-export.py https://YOUR_PROJECT.atlassian.net your_username your_api_token ./output_dir --space DOCS --skip-attachments
+```
+
+## Generating an API Token
+
+1. Go to your Confluence profile.
+2. Navigate to **Security**.
+3. Under **API Tokens**, click **Manage API Tokens**.
+4. Generate a new token and use it as the `token` argument.
+
+## Notes
+
+- The script currently supports single-threaded operation, which is safe for higher chunk sizes during downloads.
+- Ensure you have the necessary permissions to access the Confluence instance and export data.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Enhance Filename Sanitization & Readme

This PR improves the filename sanitization process in the Confluence exporter script. Specifically, it stops the script from erroring when it encounters additional invalid characters or confluence articles with a long name.

The readme has been updated for additional clarity. 

Enhanced the __sanitize_filename method to handle more invalid characters
Implemented filename truncation for long filenames which would otherwise cause the script to error
Improved the readme